### PR TITLE
feat: show filename in lightbox caption and disable end-of-batch cycling

### DIFF
--- a/inst/htmlwidgets/lib/viewerComponent.js
+++ b/inst/htmlwidgets/lib/viewerComponent.js
@@ -290,6 +290,7 @@ class ViewerComponent {
   vjs(elementID) {
     var elementID = new Viewer(document.getElementById(elementID), {
       url: 'data-original',
+      loop: false,
       title: function (image) {
         return image.alt + ' (' + (this.index + 1) + '/' + this.length + ')';
       },
@@ -480,7 +481,7 @@ class ViewerComponent {
       img.src = ((arr[i].trim()).replace(/[\[\]'"]+/g, '')).replace(/(\r\n|\n|\r)/gm, "");
 
       this.currentDisplayedImgs.push(img.src);
-      img.alt = "Camera Trap";
+      img.alt = img.src.split('/').pop();
       img.datamarked = 0;
 
       if (this.placeHolder(img.src)) {

--- a/inst/htmlwidgets/viewerimgclssfctnud.yaml
+++ b/inst/htmlwidgets/viewerimgclssfctnud.yaml
@@ -8,7 +8,7 @@ dependencies:
   src: htmlwidgets
   script: ./lib/viewerHelpers.js
 - name: viewerComponent
-  version: 1.7.0
+  version: 1.7.1
   src: htmlwidgets
   script: ./lib/viewerComponent.js
 - name: classificationHelper


### PR DESCRIPTION
## Summary

Two UX improvements to the classify module viewer, supporting the companion
PantheraIDS_v2 PR (DV-873).

- **Filename in lightbox caption**: The title shown beneath a photo when opened in the
  lightbox now displays the actual filename extracted from the image URL
  (e.g. `IMG_1234.JPG (3/21)`) instead of the hardcoded `Camera Trap (3/21)` label.
  No changes to how images are loaded — the filename is already present in the src path
  and is extracted with `img.src.split('/').pop()`.

- **Disable end-of-batch cycling**: The `Viewer` is now initialised with `loop: false`.
  Previously the viewer defaulted to `loop: true` (from `viewer.js` DEFAULTS), causing
  right-arrow on the last image to silently wrap back to photo 1 and leading to accidental
  re-review. With `loop: false` the viewer's built-in `next()` boundary handling clamps at
  the last image instead.

- **Version bump**: `viewerComponent` dependency version incremented from `1.7.0` to
  `1.7.1` in `viewerimgclssfctnud.yaml` to bust browser caches on deploy.

## Files changed

- `inst/htmlwidgets/lib/viewerComponent.js`
  - `imgloop()`: `img.alt = img.src.split('/').pop()` (was `"Camera Trap"`)
  - `vjs()`: added `loop: false` to `Viewer` constructor options
- `inst/htmlwidgets/viewerimgclssfctnud.yaml`
  - `viewerComponent` version: `1.7.0` → `1.7.1`

## Test plan

- [x] Reinstall package in Docker image and hard-refresh the browser
- [x] Open a photo in the Classify lightbox — caption should show filename
- [x] Arrow to last photo in a batch — right arrow should stop, not cycle to photo 1